### PR TITLE
feat: add liglicko2 to admin players page

### DIFF
--- a/handlers/admin/players/players.html
+++ b/handlers/admin/players/players.html
@@ -6,7 +6,7 @@
 >
   <div class="flex flex-row justify-between w-full">
     <h4 class="text-lg font-bold">{{.Name}}</h4>
-    <p>{{.Elo}} ELO</p>
+    <p>{{.Elo}} ELO | {{printf "%.0f" .Liglicko2Rating}} liglicko2</p>
   </div>
 
   <p>Played {{.GameCount}} games.</p>

--- a/handlers/admin/players/players_test.go
+++ b/handlers/admin/players/players_test.go
@@ -1,6 +1,7 @@
 package players_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Nag-s-Head/chess-league/db/model"
@@ -13,7 +14,14 @@ func TestRender(t *testing.T) {
 	db := testutils.GetDb(t)
 	defer db.Close()
 
+	player := model.NewPlayer("alice")
+	player.Elo = 1234
+	player.Liglicko2Rating = 1678.2
+	require.NoError(t, model.InsertPlayer(db, player))
+
 	tpl, err := players.Render(db)(nil, nil, model.NewAdminUser("bob", "bob", "0.0.0.0", "bob"))
 	require.NoError(t, err)
 	require.NotNil(t, tpl)
+	require.Contains(t, string(tpl), "1234 ELO | 1678 liglicko2")
+	require.True(t, strings.Contains(string(tpl), "alice"))
 }


### PR DESCRIPTION
Forgot the `admin/players` page which is a handy place to see everyone's liglicko2 ratings in one place

Before:
<img width="1910" height="211" alt="image" src="https://github.com/user-attachments/assets/937ecd2f-9fe3-4755-9208-6255e74d9bc7" />

After:
<img width="1894" height="149" alt="image" src="https://github.com/user-attachments/assets/90991568-1647-4ab3-82c6-8a7e85873906" />
