### PR TITLE
Potential fix for code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/handlers/admin/players/player_details/player_details.go
+++ b/handlers/admin/players/player_details/player_details.go
@@ -148,7 +148,7 @@ func PostPlayerDetails(db db.Db) func(*model.AdminUser) func(http.ResponseWriter
 					adminutils.RenderError(w, err)
 					return
 				}
-				w.Write([]byte(fmt.Sprintf("<input type='hidden' name='merge-player-dest' value='%s'>", destIdStr)))
+				w.Write([]byte(fmt.Sprintf("<input type='hidden' name='merge-player-dest' value='%s'>", destId.String())))
 			case "merge-confirm":
 				if !utils.IsConfirmed(r) {
 					adminutils.RenderError(w, errors.New("Not confirmed"))


### PR DESCRIPTION
Potential fix for [https://github.com/Nag-s-Head/chess-league/security/code-scanning/2](https://github.com/Nag-s-Head/chess-league/security/code-scanning/2)

To fix reflected XSS here, avoid writing raw request data into HTML. The best minimal fix is to output a trusted canonical value instead of `destIdStr`: use `destId.String()` (result of successful UUID parse) when rendering the hidden input. This preserves behavior (same semantic UUID value is submitted) and removes tainted raw input from the sink.  
In `handlers/admin/players/player_details/player_details.go`, within the `"merge-select"` case, replace the `w.Write` line that currently uses `destIdStr` with one using `destId.String()`.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
