### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Nag-s-Head/chess-league/security/code-scanning/8](https://github.com/Nag-s-Head/chess-league/security/code-scanning/8)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.

Best fix here: define workflow-level permissions right after the `on:` block (before `jobs:`), with `contents: read`. This is sufficient for `actions/checkout` and typical CI read operations, and it applies to all jobs unless overridden later. No imports, methods, or dependencies are needed—just YAML config update in `.github/workflows/go.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
